### PR TITLE
Update and streamline spring-rest-todos client deps

### DIFF
--- a/scores/src/main/resources/public/bower.json
+++ b/scores/src/main/resources/public/bower.json
@@ -28,8 +28,9 @@
 		"tests"
 	],
 	"dependencies": {
-		"rave": "~0.3",
-		"fabulous": "briancavalier/fabulous",
+		"rave": "~0.4",
+		"fabulous": "briancavalier/fabulous#0.0.1",
+		"jiff": "~0.6",
 		"sockjs-client": "bower-sockjs-client#~0.3.4",
 		"stomp-websocket": "~2.3.3"
 	}

--- a/scores/src/main/resources/public/main.js
+++ b/scores/src/main/resources/public/main.js
@@ -3,7 +3,7 @@ var jiff = require('jiff');
 var stomp = require('stomp-websocket');
 var SockJS = require('sockjs-client');
 
-module.exports = fab.runAt(document.querySelector('.scoreboard'), gameDayView);
+module.exports = fab.runAt(gameDayView, document.querySelector('.scoreboard'));
 
 function gameDayView(node, context) {
 	var stomp = Stomp.over(new SockJS('/scores'));

--- a/spring-rest-todos/src/main/resources/public/bower.json
+++ b/spring-rest-todos/src/main/resources/public/bower.json
@@ -10,10 +10,7 @@
   "author": "brian@hovercraftstudios.com",
   "license": "MIT",
   "dependencies": {
-    "fabulous": "briancavalier/fabulous#master",
-    "jiff": "~0.6",
-    "rave": "~0.4",
-    "rest": "^1.2",
-    "when": "~3.5"
+    "fabulous": "briancavalier/fabulous#0.0.1",
+    "rave": "~0.4"
   }
 }


### PR DESCRIPTION
Use fabulous 0.0.1 tag, and remove explicit transitive deps (which will be pulled in automatically by bower)
